### PR TITLE
Generate scaffolds related to Posts

### DIFF
--- a/app/assets/stylesheets/event_types.scss
+++ b/app/assets/stylesheets/event_types.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the EventTypes controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Events controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Posts controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -1,0 +1,65 @@
+body {
+  background-color: #fff;
+  color: #333;
+  margin: 33px; }
+
+body, p, ol, ul, td {
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px; }
+
+pre {
+  background-color: #eee;
+  padding: 10px;
+  font-size: 11px; }
+
+a {
+  color: #000; }
+
+a:visited {
+  color: #666; }
+
+a:hover {
+  color: #fff;
+  background-color: #000; }
+
+th {
+  padding-bottom: 5px; }
+
+td {
+  padding: 0 5px 7px; }
+
+div.field,
+div.actions {
+  margin-bottom: 10px; }
+
+#notice {
+  color: green; }
+
+.field_with_errors {
+  padding: 2px;
+  background-color: red;
+  display: table; }
+
+#error_explanation {
+  width: 450px;
+  border: 2px solid red;
+  padding: 7px 7px 0;
+  margin-bottom: 20px;
+  background-color: #f0f0f0; }
+
+#error_explanation h2 {
+  text-align: left;
+  font-weight: bold;
+  padding: 5px 5px 5px 15px;
+  font-size: 12px;
+  margin: -7px -7px 0;
+  background-color: #c00;
+  color: #fff; }
+
+#error_explanation ul li {
+  font-size: 12px;
+  list-style: square; }
+
+label {
+  display: block; }

--- a/app/controllers/event_types_controller.rb
+++ b/app/controllers/event_types_controller.rb
@@ -1,0 +1,69 @@
+class EventTypesController < ApplicationController
+  before_action :set_event_type, only: %i[ show edit update destroy ]
+
+  # GET /event_types or /event_types.json
+  def index
+    @event_types = EventType.all
+  end
+
+  # GET /event_types/1 or /event_types/1.json
+  def show
+  end
+
+  # GET /event_types/new
+  def new
+    @event_type = EventType.new
+  end
+
+  # GET /event_types/1/edit
+  def edit
+  end
+
+  # POST /event_types or /event_types.json
+  def create
+    @event_type = EventType.new(event_type_params)
+
+    respond_to do |format|
+      if @event_type.save
+        format.html { redirect_to @event_type, notice: "Event type was successfully created." }
+        format.json { render :show, status: :created, location: @event_type }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @event_type.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /event_types/1 or /event_types/1.json
+  def update
+    respond_to do |format|
+      if @event_type.update(event_type_params)
+        format.html { redirect_to @event_type, notice: "Event type was successfully updated." }
+        format.json { render :show, status: :ok, location: @event_type }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @event_type.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /event_types/1 or /event_types/1.json
+  def destroy
+    @event_type.destroy
+    respond_to do |format|
+      format.html { redirect_to event_types_url, notice: "Event type was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_event_type
+      @event_type = EventType.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def event_type_params
+      params.require(:event_type).permit(:name, :form_data)
+    end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,69 @@
+class EventsController < ApplicationController
+  before_action :set_event, only: %i[ show edit update destroy ]
+
+  # GET /events or /events.json
+  def index
+    @events = Event.all
+  end
+
+  # GET /events/1 or /events/1.json
+  def show
+  end
+
+  # GET /events/new
+  def new
+    @event = Event.new
+  end
+
+  # GET /events/1/edit
+  def edit
+  end
+
+  # POST /events or /events.json
+  def create
+    @event = Event.new(event_params)
+
+    respond_to do |format|
+      if @event.save
+        format.html { redirect_to @event, notice: "Event was successfully created." }
+        format.json { render :show, status: :created, location: @event }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @event.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /events/1 or /events/1.json
+  def update
+    respond_to do |format|
+      if @event.update(event_params)
+        format.html { redirect_to @event, notice: "Event was successfully updated." }
+        format.json { render :show, status: :ok, location: @event }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @event.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /events/1 or /events/1.json
+  def destroy
+    @event.destroy
+    respond_to do |format|
+      format.html { redirect_to events_url, notice: "Event was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_event
+      @event = Event.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def event_params
+      params.require(:event).permit(:post_id, :date, :event_type_id)
+    end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,69 @@
+class PostsController < ApplicationController
+  before_action :set_post, only: %i[ show edit update destroy ]
+
+  # GET /posts or /posts.json
+  def index
+    @posts = Post.all
+  end
+
+  # GET /posts/1 or /posts/1.json
+  def show
+  end
+
+  # GET /posts/new
+  def new
+    @post = Post.new
+  end
+
+  # GET /posts/1/edit
+  def edit
+  end
+
+  # POST /posts or /posts.json
+  def create
+    @post = Post.new(post_params)
+
+    respond_to do |format|
+      if @post.save
+        format.html { redirect_to @post, notice: "Post was successfully created." }
+        format.json { render :show, status: :created, location: @post }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @post.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /posts/1 or /posts/1.json
+  def update
+    respond_to do |format|
+      if @post.update(post_params)
+        format.html { redirect_to @post, notice: "Post was successfully updated." }
+        format.json { render :show, status: :ok, location: @post }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @post.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /posts/1 or /posts/1.json
+  def destroy
+    @post.destroy
+    respond_to do |format|
+      format.html { redirect_to posts_url, notice: "Post was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_post
+      @post = Post.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def post_params
+      params.require(:post).permit(:title, :short_description, :static_id)
+    end
+end

--- a/app/helpers/event_types_helper.rb
+++ b/app/helpers/event_types_helper.rb
@@ -1,0 +1,2 @@
+module EventTypesHelper
+end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,0 +1,2 @@
+module EventsHelper
+end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,0 +1,2 @@
+module PostsHelper
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,4 @@
+class Event < ApplicationRecord
+  belongs_to :post
+  belongs_to :event_type
+end

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -1,0 +1,3 @@
+class EventType < ApplicationRecord
+  has_many :events
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,4 @@
+class Post < ApplicationRecord
+  has_one :event
+  enum static_id: [:about]
+end

--- a/app/views/event_types/_event_type.json.jbuilder
+++ b/app/views/event_types/_event_type.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! event_type, :id, :name, :form_data, :created_at, :updated_at
+json.url event_type_url(event_type, format: :json)

--- a/app/views/event_types/_form.html.erb
+++ b/app/views/event_types/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: event_type, local: true) do |form| %>
+  <% if event_type.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(event_type.errors.count, "error") %> prohibited this event_type from being saved:</h2>
+
+      <ul>
+        <% event_type.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div class="field">
+    <%= form.label :form_data %>
+    <%= form.text_field :form_data %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/event_types/edit.html.erb
+++ b/app/views/event_types/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Event Type</h1>
+
+<%= render 'form', event_type: @event_type %>
+
+<%= link_to 'Show', @event_type %> |
+<%= link_to 'Back', event_types_path %>

--- a/app/views/event_types/index.html.erb
+++ b/app/views/event_types/index.html.erb
@@ -1,0 +1,29 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Event Types</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Form data</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @event_types.each do |event_type| %>
+      <tr>
+        <td><%= event_type.name %></td>
+        <td><%= event_type.form_data %></td>
+        <td><%= link_to 'Show', event_type %></td>
+        <td><%= link_to 'Edit', edit_event_type_path(event_type) %></td>
+        <td><%= link_to 'Destroy', event_type, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Event Type', new_event_type_path %>

--- a/app/views/event_types/index.json.jbuilder
+++ b/app/views/event_types/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @event_types, partial: "event_types/event_type", as: :event_type

--- a/app/views/event_types/new.html.erb
+++ b/app/views/event_types/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Event Type</h1>
+
+<%= render 'form', event_type: @event_type %>
+
+<%= link_to 'Back', event_types_path %>

--- a/app/views/event_types/show.html.erb
+++ b/app/views/event_types/show.html.erb
@@ -1,0 +1,14 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Name:</strong>
+  <%= @event_type.name %>
+</p>
+
+<p>
+  <strong>Form data:</strong>
+  <%= @event_type.form_data %>
+</p>
+
+<%= link_to 'Edit', edit_event_type_path(@event_type) %> |
+<%= link_to 'Back', event_types_path %>

--- a/app/views/event_types/show.json.jbuilder
+++ b/app/views/event_types/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "event_types/event_type", event_type: @event_type

--- a/app/views/events/_event.json.jbuilder
+++ b/app/views/events/_event.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! event, :id, :post_id, :date, :event_type_id, :created_at, :updated_at
+json.url event_url(event, format: :json)

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with(model: event, local: true) do |form| %>
+  <% if event.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(event.errors.count, "error") %> prohibited this event from being saved:</h2>
+
+      <ul>
+        <% event.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :post_id %>
+    <%= form.text_field :post_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :date %>
+    <%= form.datetime_select :date %>
+  </div>
+
+  <div class="field">
+    <%= form.label :event_type_id %>
+    <%= form.number_field :event_type_id %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Event</h1>
+
+<%= render 'form', event: @event %>
+
+<%= link_to 'Show', @event %> |
+<%= link_to 'Back', events_path %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,31 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Events</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Post</th>
+      <th>Date</th>
+      <th>Event type</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @events.each do |event| %>
+      <tr>
+        <td><%= event.post_id %></td>
+        <td><%= event.date %></td>
+        <td><%= event.event_type_id %></td>
+        <td><%= link_to 'Show', event %></td>
+        <td><%= link_to 'Edit', edit_event_path(event) %></td>
+        <td><%= link_to 'Destroy', event, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Event', new_event_path %>

--- a/app/views/events/index.json.jbuilder
+++ b/app/views/events/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @events, partial: "events/event", as: :event

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Event</h1>
+
+<%= render 'form', event: @event %>
+
+<%= link_to 'Back', events_path %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,19 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Post:</strong>
+  <%= @event.post_id %>
+</p>
+
+<p>
+  <strong>Date:</strong>
+  <%= @event.date %>
+</p>
+
+<p>
+  <strong>Event type:</strong>
+  <%= @event.event_type_id %>
+</p>
+
+<%= link_to 'Edit', edit_event_path(@event) %> |
+<%= link_to 'Back', events_path %>

--- a/app/views/events/show.json.jbuilder
+++ b/app/views/events/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "events/event", event: @event

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with(model: post, local: true) do |form| %>
+  <% if post.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(post.errors.count, "error") %> prohibited this post from being saved:</h2>
+
+      <ul>
+        <% post.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :short_description %>
+    <%= form.text_field :short_description %>
+  </div>
+
+  <div class="field">
+    <%= form.label :static_id %>
+    <%= form.number_field :static_id %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/posts/_post.json.jbuilder
+++ b/app/views/posts/_post.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! post, :id, :title, :short_description, :static_id, :created_at, :updated_at
+json.url post_url(post, format: :json)

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Post</h1>
+
+<%= render 'form', post: @post %>
+
+<%= link_to 'Show', @post %> |
+<%= link_to 'Back', posts_path %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,31 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Posts</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th>Short description</th>
+      <th>Static</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @posts.each do |post| %>
+      <tr>
+        <td><%= post.title %></td>
+        <td><%= post.short_description %></td>
+        <td><%= post.static_id %></td>
+        <td><%= link_to 'Show', post %></td>
+        <td><%= link_to 'Edit', edit_post_path(post) %></td>
+        <td><%= link_to 'Destroy', post, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Post', new_post_path %>

--- a/app/views/posts/index.json.jbuilder
+++ b/app/views/posts/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @posts, partial: "posts/post", as: :post

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Post</h1>
+
+<%= render 'form', post: @post %>
+
+<%= link_to 'Back', posts_path %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,19 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Title:</strong>
+  <%= @post.title %>
+</p>
+
+<p>
+  <strong>Short description:</strong>
+  <%= @post.short_description %>
+</p>
+
+<p>
+  <strong>Static:</strong>
+  <%= @post.static_id %>
+</p>
+
+<%= link_to 'Edit', edit_post_path(@post) %> |
+<%= link_to 'Back', posts_path %>

--- a/app/views/posts/show.json.jbuilder
+++ b/app/views/posts/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "posts/post", post: @post

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
 Rails.application.routes.draw do
+  resources :event_types
+  resources :events
+  resources :posts
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20210201170431_create_posts.rb
+++ b/db/migrate/20210201170431_create_posts.rb
@@ -1,0 +1,11 @@
+class CreatePosts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :posts do |t|
+      t.string :title
+      t.string :short_description
+      t.integer :static_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210201184552_create_events.rb
+++ b/db/migrate/20210201184552_create_events.rb
@@ -1,0 +1,11 @@
+class CreateEvents < ActiveRecord::Migration[6.0]
+  def change
+    create_table :events do |t|
+      t.references :post, null: false, foreign_key: true
+      t.datetime :date
+      t.integer :event_type_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210201184945_create_event_types.rb
+++ b/db/migrate/20210201184945_create_event_types.rb
@@ -1,0 +1,10 @@
+class CreateEventTypes < ActiveRecord::Migration[6.0]
+  def change
+    create_table :event_types do |t|
+      t.string :name
+      t.json :form_data
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,34 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2021_02_01_184945) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "event_types", force: :cascade do |t|
+    t.string "name"
+    t.json "form_data"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "events", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.datetime "date"
+    t.integer "event_type_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_events_on_post_id"
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.string "title"
+    t.string "short_description"
+    t.integer "static_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  add_foreign_key "events", "posts"
 end

--- a/test/controllers/event_types_controller_test.rb
+++ b/test/controllers/event_types_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class EventTypesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @event_type = event_types(:one)
+  end
+
+  test "should get index" do
+    get event_types_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_event_type_url
+    assert_response :success
+  end
+
+  test "should create event_type" do
+    assert_difference('EventType.count') do
+      post event_types_url, params: { event_type: { form_data: @event_type.form_data, name: @event_type.name } }
+    end
+
+    assert_redirected_to event_type_url(EventType.last)
+  end
+
+  test "should show event_type" do
+    get event_type_url(@event_type)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_event_type_url(@event_type)
+    assert_response :success
+  end
+
+  test "should update event_type" do
+    patch event_type_url(@event_type), params: { event_type: { form_data: @event_type.form_data, name: @event_type.name } }
+    assert_redirected_to event_type_url(@event_type)
+  end
+
+  test "should destroy event_type" do
+    assert_difference('EventType.count', -1) do
+      delete event_type_url(@event_type)
+    end
+
+    assert_redirected_to event_types_url
+  end
+end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class EventsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = events(:one)
+  end
+
+  test "should get index" do
+    get events_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_event_url
+    assert_response :success
+  end
+
+  test "should create event" do
+    assert_difference('Event.count') do
+      post events_url, params: { event: { date: @event.date, event_type_id: @event.event_type_id, post_id: @event.post_id } }
+    end
+
+    assert_redirected_to event_url(Event.last)
+  end
+
+  test "should show event" do
+    get event_url(@event)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_event_url(@event)
+    assert_response :success
+  end
+
+  test "should update event" do
+    patch event_url(@event), params: { event: { date: @event.date, event_type_id: @event.event_type_id, post_id: @event.post_id } }
+    assert_redirected_to event_url(@event)
+  end
+
+  test "should destroy event" do
+    assert_difference('Event.count', -1) do
+      delete event_url(@event)
+    end
+
+    assert_redirected_to events_url
+  end
+end

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class PostsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @post = posts(:one)
+  end
+
+  test "should get index" do
+    get posts_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_post_url
+    assert_response :success
+  end
+
+  test "should create post" do
+    assert_difference('Post.count') do
+      post posts_url, params: { post: { short_description: @post.short_description, static_id: @post.static_id, title: @post.title } }
+    end
+
+    assert_redirected_to post_url(Post.last)
+  end
+
+  test "should show post" do
+    get post_url(@post)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_post_url(@post)
+    assert_response :success
+  end
+
+  test "should update post" do
+    patch post_url(@post), params: { post: { short_description: @post.short_description, static_id: @post.static_id, title: @post.title } }
+    assert_redirected_to post_url(@post)
+  end
+
+  test "should destroy post" do
+    assert_difference('Post.count', -1) do
+      delete post_url(@post)
+    end
+
+    assert_redirected_to posts_url
+  end
+end

--- a/test/fixtures/event_types.yml
+++ b/test/fixtures/event_types.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  form_data: 
+
+two:
+  name: MyString
+  form_data: 

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  post: one
+  date: 2021-02-01 19:45:52
+  event_type_id: 1
+
+two:
+  post: two
+  date: 2021-02-01 19:45:52
+  event_type_id: 1

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  short_description: MyString
+  static_id: 1
+
+two:
+  title: MyString
+  short_description: MyString
+  static_id: 1

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class EventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/event_type_test.rb
+++ b/test/models/event_type_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class EventTypeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/event_types_test.rb
+++ b/test/system/event_types_test.rb
@@ -1,0 +1,45 @@
+require "application_system_test_case"
+
+class EventTypesTest < ApplicationSystemTestCase
+  setup do
+    @event_type = event_types(:one)
+  end
+
+  test "visiting the index" do
+    visit event_types_url
+    assert_selector "h1", text: "Event Types"
+  end
+
+  test "creating a Event type" do
+    visit event_types_url
+    click_on "New Event Type"
+
+    fill_in "Form data", with: @event_type.form_data
+    fill_in "Name", with: @event_type.name
+    click_on "Create Event type"
+
+    assert_text "Event type was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Event type" do
+    visit event_types_url
+    click_on "Edit", match: :first
+
+    fill_in "Form data", with: @event_type.form_data
+    fill_in "Name", with: @event_type.name
+    click_on "Update Event type"
+
+    assert_text "Event type was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Event type" do
+    visit event_types_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Event type was successfully destroyed"
+  end
+end

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -1,0 +1,47 @@
+require "application_system_test_case"
+
+class EventsTest < ApplicationSystemTestCase
+  setup do
+    @event = events(:one)
+  end
+
+  test "visiting the index" do
+    visit events_url
+    assert_selector "h1", text: "Events"
+  end
+
+  test "creating a Event" do
+    visit events_url
+    click_on "New Event"
+
+    fill_in "Date", with: @event.date
+    fill_in "Event type", with: @event.event_type_id
+    fill_in "Post", with: @event.post_id
+    click_on "Create Event"
+
+    assert_text "Event was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Event" do
+    visit events_url
+    click_on "Edit", match: :first
+
+    fill_in "Date", with: @event.date
+    fill_in "Event type", with: @event.event_type_id
+    fill_in "Post", with: @event.post_id
+    click_on "Update Event"
+
+    assert_text "Event was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Event" do
+    visit events_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Event was successfully destroyed"
+  end
+end

--- a/test/system/posts_test.rb
+++ b/test/system/posts_test.rb
@@ -1,0 +1,47 @@
+require "application_system_test_case"
+
+class PostsTest < ApplicationSystemTestCase
+  setup do
+    @post = posts(:one)
+  end
+
+  test "visiting the index" do
+    visit posts_url
+    assert_selector "h1", text: "Posts"
+  end
+
+  test "creating a Post" do
+    visit posts_url
+    click_on "New Post"
+
+    fill_in "Short description", with: @post.short_description
+    fill_in "Static", with: @post.static_id
+    fill_in "Title", with: @post.title
+    click_on "Create Post"
+
+    assert_text "Post was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Post" do
+    visit posts_url
+    click_on "Edit", match: :first
+
+    fill_in "Short description", with: @post.short_description
+    fill_in "Static", with: @post.static_id
+    fill_in "Title", with: @post.title
+    click_on "Update Post"
+
+    assert_text "Post was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Post" do
+    visit posts_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Post was successfully destroyed"
+  end
+end


### PR DESCRIPTION
* add post model
* add event model
* add event_type model
* add basic associations

Made some changes, to the modell:
* The `name` attribute of the Post is changed to `static_id` enum. Represents the intention better.
* In the final version of the ER diagram a `Gallery` and a `FormattedDocument` entity only exists through a Post, so for now they are ommited from the model

The images and rtf documents will be impleneted in an other PR