### PR TITLE
Remove Jbuilder generated endpoints and configurate

### DIFF
--- a/app/controllers/event_types_controller.rb
+++ b/app/controllers/event_types_controller.rb
@@ -1,12 +1,12 @@
 class EventTypesController < ApplicationController
   before_action :set_event_type, only: %i[ show edit update destroy ]
 
-  # GET /event_types or /event_types.json
+  # GET /event_types
   def index
     @event_types = EventType.all
   end
 
-  # GET /event_types/1 or /event_types/1.json
+  # GET /event_types/1
   def show
   end
 
@@ -19,41 +19,30 @@ class EventTypesController < ApplicationController
   def edit
   end
 
-  # POST /event_types or /event_types.json
+  # POST /event_types
   def create
     @event_type = EventType.new(event_type_params)
 
-    respond_to do |format|
-      if @event_type.save
-        format.html { redirect_to @event_type, notice: "Event type was successfully created." }
-        format.json { render :show, status: :created, location: @event_type }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @event_type.errors, status: :unprocessable_entity }
-      end
+    if @event_type.save
+      redirect_to @event_type, notice: "Event type was successfully created."
+    else
+      render :new, status: :unprocessable_entity
     end
   end
 
-  # PATCH/PUT /event_types/1 or /event_types/1.json
+  # PATCH/PUT /event_types/1
   def update
-    respond_to do |format|
-      if @event_type.update(event_type_params)
-        format.html { redirect_to @event_type, notice: "Event type was successfully updated." }
-        format.json { render :show, status: :ok, location: @event_type }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @event_type.errors, status: :unprocessable_entity }
-      end
+    if @event_type.update(event_type_params)
+      redirect_to @event_type, notice: "Event type was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 
-  # DELETE /event_types/1 or /event_types/1.json
+  # DELETE /event_types/1
   def destroy
     @event_type.destroy
-    respond_to do |format|
-      format.html { redirect_to event_types_url, notice: "Event type was successfully destroyed." }
-      format.json { head :no_content }
-    end
+    redirect_to event_types_url, notice: "Event type was successfully destroyed."
   end
 
   private

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,12 +1,12 @@
 class EventsController < ApplicationController
   before_action :set_event, only: %i[ show edit update destroy ]
 
-  # GET /events or /events.json
+  # GET /events
   def index
     @events = Event.all
   end
 
-  # GET /events/1 or /events/1.json
+  # GET /events/1
   def show
   end
 
@@ -19,41 +19,30 @@ class EventsController < ApplicationController
   def edit
   end
 
-  # POST /events or /events.json
+  # POST /events
   def create
     @event = Event.new(event_params)
 
-    respond_to do |format|
-      if @event.save
-        format.html { redirect_to @event, notice: "Event was successfully created." }
-        format.json { render :show, status: :created, location: @event }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @event.errors, status: :unprocessable_entity }
-      end
+    if @event.save
+      redirect_to @event, notice: "Event was successfully created."
+    else
+      render :new, status: :unprocessable_entity
     end
   end
 
-  # PATCH/PUT /events/1 or /events/1.json
+  # PATCH/PUT /events/1
   def update
-    respond_to do |format|
-      if @event.update(event_params)
-        format.html { redirect_to @event, notice: "Event was successfully updated." }
-        format.json { render :show, status: :ok, location: @event }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @event.errors, status: :unprocessable_entity }
-      end
+    if @event.update(event_params)
+      redirect_to @event, notice: "Event was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 
-  # DELETE /events/1 or /events/1.json
+  # DELETE /events/1
   def destroy
     @event.destroy
-    respond_to do |format|
-      format.html { redirect_to events_url, notice: "Event was successfully destroyed." }
-      format.json { head :no_content }
-    end
+    redirect_to events_url, notice: "Event was successfully destroyed."
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,12 +1,12 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: %i[ show edit update destroy ]
 
-  # GET /items or /items.json
+  # GET /items
   def index
     @items = Item.all
   end
 
-  # GET /items/1 or /items/1.json
+  # GET /items/1
   def show
   end
 
@@ -19,41 +19,30 @@ class ItemsController < ApplicationController
   def edit
   end
 
-  # POST /items or /items.json
+  # POST /items
   def create
     @item = Item.new(item_params)
 
-    respond_to do |format|
-      if @item.save
-        format.html { redirect_to @item, notice: "Item was successfully created." }
-        format.json { render :show, status: :created, location: @item }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @item.errors, status: :unprocessable_entity }
-      end
+    if @item.save
+      redirect_to @item, notice: "Item was successfully created."
+    else
+      render :new, status: :unprocessable_entity
     end
   end
 
-  # PATCH/PUT /items/1 or /items/1.json
+  # PATCH/PUT /items/1
   def update
-    respond_to do |format|
-      if @item.update(item_params)
-        format.html { redirect_to @item, notice: "Item was successfully updated." }
-        format.json { render :show, status: :ok, location: @item }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @item.errors, status: :unprocessable_entity }
-      end
+    if @item.update(item_params)
+      redirect_to @item, notice: "Item was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 
-  # DELETE /items/1 or /items/1.json
+  # DELETE /items/1
   def destroy
     @item.destroy
-    respond_to do |format|
-      format.html { redirect_to items_url, notice: "Item was successfully destroyed." }
-      format.json { head :no_content }
-    end
+    redirect_to items_url, notice: "Item was successfully destroyed."
   end
 
   private

--- a/app/controllers/participations_controller.rb
+++ b/app/controllers/participations_controller.rb
@@ -1,12 +1,12 @@
 class ParticipationsController < ApplicationController
   before_action :set_participation, only: %i[ show edit update destroy ]
 
-  # GET /participations or /participations.json
+  # GET /participations
   def index
     @participations = Participation.all
   end
 
-  # GET /participations/1 or /participations/1.json
+  # GET /participations/1
   def show
   end
 
@@ -19,41 +19,30 @@ class ParticipationsController < ApplicationController
   def edit
   end
 
-  # POST /participations or /participations.json
+  # POST /participations
   def create
     @participation = Participation.new(participation_params)
 
-    respond_to do |format|
-      if @participation.save
-        format.html { redirect_to @participation, notice: "Participation was successfully created." }
-        format.json { render :show, status: :created, location: @participation }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @participation.errors, status: :unprocessable_entity }
-      end
+    if @participation.save
+      redirect_to @participation, notice: "Participation was successfully created."
+    else
+      render :new, status: :unprocessable_entity
     end
   end
 
-  # PATCH/PUT /participations/1 or /participations/1.json
+  # PATCH/PUT /participations/1
   def update
-    respond_to do |format|
-      if @participation.update(participation_params)
-        format.html { redirect_to @participation, notice: "Participation was successfully updated." }
-        format.json { render :show, status: :ok, location: @participation }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @participation.errors, status: :unprocessable_entity }
-      end
+    if @participation.update(participation_params)
+      redirect_to @participation, notice: "Participation was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 
-  # DELETE /participations/1 or /participations/1.json
+  # DELETE /participations/1
   def destroy
     @participation.destroy
-    respond_to do |format|
-      format.html { redirect_to participations_url, notice: "Participation was successfully destroyed." }
-      format.json { head :no_content }
-    end
+    redirect_to participations_url, notice: "Participation was successfully destroyed."
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,12 +1,12 @@
 class PostsController < ApplicationController
   before_action :set_post, only: %i[ show edit update destroy ]
 
-  # GET /posts or /posts.json
+  # GET /posts
   def index
     @posts = Post.all
   end
 
-  # GET /posts/1 or /posts/1.json
+  # GET /posts/1
   def show
   end
 
@@ -19,7 +19,7 @@ class PostsController < ApplicationController
   def edit
   end
 
-  # POST /posts or /posts.json
+  # POST /posts
   def create
     @post = Post.new(post_params)
 
@@ -30,7 +30,7 @@ class PostsController < ApplicationController
     end
   end
 
-  # PATCH/PUT /posts/1 or /posts/1.json
+  # PATCH/PUT /posts/1 
   def update
     if @post.update(post_params)
       redirect_to @post, notice: "Post was successfully updated."

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -23,37 +23,26 @@ class PostsController < ApplicationController
   def create
     @post = Post.new(post_params)
 
-    respond_to do |format|
-      if @post.save
-        format.html { redirect_to @post, notice: "Post was successfully created." }
-        format.json { render :show, status: :created, location: @post }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @post.errors, status: :unprocessable_entity }
-      end
+    if @post.save
+      redirect_to @post, notice: "Post was successfully created."
+    else
+      render :new, status: :unprocessable_entity
     end
   end
 
   # PATCH/PUT /posts/1 or /posts/1.json
   def update
-    respond_to do |format|
-      if @post.update(post_params)
-        format.html { redirect_to @post, notice: "Post was successfully updated." }
-        format.json { render :show, status: :ok, location: @post }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @post.errors, status: :unprocessable_entity }
-      end
+    if @post.update(post_params)
+      redirect_to @post, notice: "Post was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 
-  # DELETE /posts/1 or /posts/1.json
+  # DELETE /posts/1
   def destroy
     @post.destroy
-    respond_to do |format|
-      format.html { redirect_to posts_url, notice: "Post was successfully destroyed." }
-      format.json { head :no_content }
-    end
+    redirect_to posts_url, notice: "Post was successfully destroyed."
   end
 
   # GET /about

--- a/app/controllers/rents_controller.rb
+++ b/app/controllers/rents_controller.rb
@@ -1,12 +1,12 @@
 class RentsController < ApplicationController
   before_action :set_rent, only: %i[ show edit update destroy ]
 
-  # GET /rents or /rents.json
+  # GET /rents
   def index
     @rents = Rent.all
   end
 
-  # GET /rents/1 or /rents/1.json
+  # GET /rents/1
   def show
   end
 
@@ -19,41 +19,30 @@ class RentsController < ApplicationController
   def edit
   end
 
-  # POST /rents or /rents.json
+  # POST /rents
   def create
     @rent = Rent.new(rent_params)
 
-    respond_to do |format|
-      if @rent.save
-        format.html { redirect_to @rent, notice: "Rent was successfully created." }
-        format.json { render :show, status: :created, location: @rent }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @rent.errors, status: :unprocessable_entity }
-      end
+    if @rent.save
+      redirect_to @rent, notice: "Rent was successfully created."
+    else
+      render :new, status: :unprocessable_entity
     end
   end
 
-  # PATCH/PUT /rents/1 or /rents/1.json
+  # PATCH/PUT /rents/1
   def update
-    respond_to do |format|
-      if @rent.update(rent_params)
-        format.html { redirect_to @rent, notice: "Rent was successfully updated." }
-        format.json { render :show, status: :ok, location: @rent }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @rent.errors, status: :unprocessable_entity }
-      end
+    if @rent.update(rent_params)
+      redirect_to @rent, notice: "Rent was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 
-  # DELETE /rents/1 or /rents/1.json
+  # DELETE /rents/1
   def destroy
     @rent.destroy
-    respond_to do |format|
-      format.html { redirect_to rents_url, notice: "Rent was successfully destroyed." }
-      format.json { head :no_content }
-    end
+    redirect_to rents_url, notice: "Rent was successfully destroyed."
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,12 +1,12 @@
 class UsersController < ApplicationController
   before_action :set_user, only: %i[ show edit update destroy ]
 
-  # GET /users or /users.json
+  # GET /users
   def index
     @users = User.all
   end
 
-  # GET /users/1 or /users/1.json
+  # GET /users/1
   def show
   end
 
@@ -19,41 +19,30 @@ class UsersController < ApplicationController
   def edit
   end
 
-  # POST /users or /users.json
+  # POST /users
   def create
     @user = User.new(user_params)
 
-    respond_to do |format|
-      if @user.save
-        format.html { redirect_to @user, notice: "User was successfully created." }
-        format.json { render :show, status: :created, location: @user }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @user.errors, status: :unprocessable_entity }
-      end
+    if @user.save
+      redirect_to @user, notice: "User was successfully created."
+    else
+      render :new, status: :unprocessable_entity
     end
   end
 
-  # PATCH/PUT /users/1 or /users/1.json
+  # PATCH/PUT /users/1
   def update
-    respond_to do |format|
-      if @user.update(user_params)
-        format.html { redirect_to @user, notice: "User was successfully updated." }
-        format.json { render :show, status: :ok, location: @user }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @user.errors, status: :unprocessable_entity }
-      end
+    if @user.update(user_params)
+      redirect_to @user, notice: "User was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 
-  # DELETE /users/1 or /users/1.json
+  # DELETE /users/1
   def destroy
     @user.destroy
-    respond_to do |format|
-      format.html { redirect_to users_url, notice: "User was successfully destroyed." }
-      format.json { head :no_content }
-    end
+    redirect_to users_url, notice: "User was successfully destroyed."
   end
 
   private

--- a/app/views/event_types/_event_type.json.jbuilder
+++ b/app/views/event_types/_event_type.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! event_type, :id, :name, :form_data, :created_at, :updated_at
-json.url event_type_url(event_type, format: :json)

--- a/app/views/event_types/index.json.jbuilder
+++ b/app/views/event_types/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @event_types, partial: "event_types/event_type", as: :event_type

--- a/app/views/event_types/show.json.jbuilder
+++ b/app/views/event_types/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "event_types/event_type", event_type: @event_type

--- a/app/views/events/_event.json.jbuilder
+++ b/app/views/events/_event.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! event, :id, :post_id, :date, :event_type_id, :created_at, :updated_at
-json.url event_url(event, format: :json)

--- a/app/views/events/index.json.jbuilder
+++ b/app/views/events/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @events, partial: "events/event", as: :event

--- a/app/views/events/show.json.jbuilder
+++ b/app/views/events/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "events/event", event: @event

--- a/app/views/items/_item.json.jbuilder
+++ b/app/views/items/_item.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! item, :id, :name, :description, :created_at, :updated_at
-json.url item_url(item, format: :json)

--- a/app/views/items/index.json.jbuilder
+++ b/app/views/items/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @items, partial: "items/item", as: :item

--- a/app/views/items/show.json.jbuilder
+++ b/app/views/items/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "items/item", item: @item

--- a/app/views/participations/_participation.json.jbuilder
+++ b/app/views/participations/_participation.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! participation, :id, :user_id, :event_id, :created_at, :updated_at
-json.url participation_url(participation, format: :json)

--- a/app/views/participations/index.json.jbuilder
+++ b/app/views/participations/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @participations, partial: "participations/participation", as: :participation

--- a/app/views/participations/show.json.jbuilder
+++ b/app/views/participations/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "participations/participation", participation: @participation

--- a/app/views/posts/_post.json.jbuilder
+++ b/app/views/posts/_post.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! post, :id, :title, :short_description, :static_id, :created_at, :updated_at
-json.url post_url(post, format: :json)

--- a/app/views/posts/index.json.jbuilder
+++ b/app/views/posts/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @posts, partial: "posts/post", as: :post

--- a/app/views/posts/show.json.jbuilder
+++ b/app/views/posts/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "posts/post", post: @post

--- a/app/views/rents/_rent.json.jbuilder
+++ b/app/views/rents/_rent.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! rent, :id, :end_date, :item_id, :user_id, :created_at, :updated_at
-json.url rent_url(rent, format: :json)

--- a/app/views/rents/index.json.jbuilder
+++ b/app/views/rents/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @rents, partial: "rents/rent", as: :rent

--- a/app/views/rents/show.json.jbuilder
+++ b/app/views/rents/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "rents/rent", rent: @rent

--- a/app/views/users/_user.json.jbuilder
+++ b/app/views/users/_user.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! user, :id, :name, :email, :password, :admin, :created_at, :updated_at
-json.url user_url(user, format: :json)

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @users, partial: "users/user", as: :user

--- a/app/views/users/show.json.jbuilder
+++ b/app/views/users/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "users/user", user: @user

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,10 @@ module Airsoft
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    config.generators do |g|
+      g.assets            false
+      g.jbuilder          false
+    end
   end
 end


### PR DESCRIPTION
Closes #18 

### What's new:
* Removed the `.jbuilder` files from views
* Removed json from comments
* Removed `respond_to` blocks (their json endpoints)
* Configured the application to never create asset and jbuilder files when using scaffolds in the future
- Only one exception was made: Didn't touch albums' controller, as there's another PR already touching it: #35 (sorry)

#### Questions:
* Did we need any of those json endpoints?
* Will we use json endpoints in the future? (REST)