### PR TITLE
Change event model

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -55,6 +55,6 @@ class EventsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def event_params
-    params.require(:event).permit(:post_id, :date, :event_type_id)
+    params.require(:event).permit(:name, :date, :event_type_id)
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -55,6 +55,6 @@ class EventsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def event_params
-    params.require(:event).permit(:name, :date, :event_type_id)
+    params.require(:event).permit(:name, :date, :event_type_id, :description)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,21 +4,12 @@
 #
 #  id            :bigint           not null, primary key
 #  date          :datetime
+#  name          :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  event_type_id :integer
-#  post_id       :bigint           not null
-#
-# Indexes
-#
-#  index_events_on_post_id  (post_id)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (post_id => posts.id)
 #
 class Event < ApplicationRecord
-  belongs_to :post
   belongs_to :event_type, optional: true
   has_many :participations
   has_many :users, through: :participations

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -13,5 +13,6 @@ class Event < ApplicationRecord
   belongs_to :event_type, optional: true
   has_many :participations
   has_many :users, through: :participations
+  has_rich_text :description
   alias participants users
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,7 +10,6 @@
 #  updated_at        :datetime         not null
 #
 class Post < ApplicationRecord
-  has_one :event
   has_one :album
   has_rich_text :formatted_document
   enum static_id: [:common, :about]

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -13,10 +13,10 @@
 
   <div class="input-group mb-12 mb-2">
     <div class="input-group-prepend">
-      <%= form.label :name,"Esemény neve", class: "input-group-text" %>
+      <%= form.label :name, "Esemény neve", class: "input-group-text" %>
 
     </div>
-    <%= form.text_field :name, class: "form-control"%>
+    <%= form.text_field :name, class: "form-control" %>
   </div>
 
   <div class="input-group mb-12 mb-2">
@@ -38,7 +38,9 @@
                     class:         "form-control" %>
   </div>
 
-
+  <div class="field">
+    <%= form.rich_text_area :description %>
+  </div>
 
   <div class="button-collection mt-2">
     <div class="d-flex justify-content-left ">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -13,10 +13,10 @@
 
   <div class="input-group mb-12 mb-2">
     <div class="input-group-prepend">
-      <%= form.label :post_id, class: "input-group-text" %>
+      <%= form.label :name,"Esemény neve", class: "input-group-text" %>
 
     </div>
-    <%= form.text_field :post_id, class: "form-control" %>
+    <%= form.text_field :name, class: "form-control"%>
   </div>
 
   <div class="input-group mb-12 mb-2">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -9,7 +9,9 @@
   <strong>Date:</strong>
   <%= @event.date %>
 </p>
-
+<div>
+  <%= @event.description %>
+</div>
 <p>
   <% if @event.event_type %>
     <%= link_to 'Regisztrálok', register_to_event_path(@event), class: "btn btn-success" %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,8 +1,8 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Post:</strong>
-  <%= @event.post_id %>
+  <strong>Esemény neve:</strong>
+  <%= @event.name %>
 </p>
 
 <p>
@@ -11,8 +11,9 @@
 </p>
 
 <p>
-  <strong>Event type:</strong>
-  <%= @event.event_type_id %>
+  <% if @event.event_type %>
+    <%= link_to 'Regisztrálok', register_to_event_path(@event), class: "btn btn-success" %>
+  <% end %>
 </p>
 
 <% if admin_signed_in? %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -20,9 +20,6 @@
     <div class="button-collection">
       <div class="d-flex justify-content-between">
         <%= link_to 'Vissza', posts_path, class: "btn btn-success" %>
-        <% if @post.event&.event_type %>
-          <%= link_to 'Regisztrálok', register_to_event_path(@post.event), class: "btn btn-success" %>
-        <% end %>
         <% if admin_signed_in? %>
           <%= link_to 'Szerkesztés', edit_post_path(@post), class: "btn btn-success " %>
         <% end %>

--- a/db/migrate/20210630135437_remove_post_id_from_event.rb
+++ b/db/migrate/20210630135437_remove_post_id_from_event.rb
@@ -1,0 +1,5 @@
+class RemovePostIdFromEvent < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :events, :post_id, :bigint
+  end
+end

--- a/db/migrate/20210630140224_add_name_to_event.rb
+++ b/db/migrate/20210630140224_add_name_to_event.rb
@@ -1,0 +1,5 @@
+class AddNameToEvent < ActiveRecord::Migration[6.0]
+  def change
+    add_column :events, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_19_180141) do
+ActiveRecord::Schema.define(version: 2021_06_30_140224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,12 +62,11 @@ ActiveRecord::Schema.define(version: 2021_06_19_180141) do
   end
 
   create_table "events", force: :cascade do |t|
-    t.bigint "post_id", null: false
     t.datetime "date"
     t.integer "event_type_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_events_on_post_id"
+    t.string "name"
   end
 
   create_table "items", force: :cascade do |t|
@@ -123,7 +122,6 @@ ActiveRecord::Schema.define(version: 2021_06_19_180141) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "events", "posts"
   add_foreign_key "participations", "events"
   add_foreign_key "participations", "users"
   add_foreign_key "rents", "items"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,14 +6,8 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-p1 = Post.create(title:             "Registration test",
-                 short_description: "Test the event registration")
-
-p2 = Post.create(title:             "Registration test",
-                 short_description: "Test the event registration, but shorter form")
-
-Post.create(title:             "No registration",
-            short_description: "Ehhez a posthoz nincs esemény")
+Post.create(title:             "Test Post",
+            short_description: "Test short description")
 
 et = EventType.create(name:     "Demo form",
                       schema:   '{"type":"object","title":"","properties":{"email":{"title":"E-mail","type":"string","format":"email"},"name":{"title":"Becenév","type":"string","default":"John Doe"},"id":{"title":"Személyi igazolvány szám","type":"string"},"glasses":{"enum":["igen","nem"],"title":"Szemüveges vagyok","type":"string"},"other":{"title":"Megjegyzés","type":"string"},"eula":{"title":"A szabályzatot elfogadom","type":"boolean"}},"dependencies":{},"required":["email","name","id","glasses","eula"]}',
@@ -23,5 +17,4 @@ et_short = EventType.create(name:     "Short form",
                             schema:   '{"type":"object","properties":{"yes":{"enum":["nem"],"title":"Igen?","type":"string"}},"dependencies":{},"required":["yes"],"title":"","description":""}',
                             uischema: '{"yes":{"ui:widget":"radio"},"ui:order":["yes"]}')
 
-Event.create(post: p1, event_type: et)
-Event.create(post: p2, event_type: et_short)
+Event.create(name: "Test event", event_type: et)

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -4,18 +4,10 @@
 #
 #  id            :bigint           not null, primary key
 #  date          :datetime
+#  name          :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  event_type_id :integer
-#  post_id       :bigint           not null
-#
-# Indexes
-#
-#  index_events_on_post_id  (post_id)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (post_id => posts.id)
 #
 
 one:

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -4,18 +4,10 @@
 #
 #  id            :bigint           not null, primary key
 #  date          :datetime
+#  name          :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  event_type_id :integer
-#  post_id       :bigint           not null
-#
-# Indexes
-#
-#  index_events_on_post_id  (post_id)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (post_id => posts.id)
 #
 require 'test_helper'
 


### PR DESCRIPTION
Refactor the event model. At first linking every `Event` to a `Post` sounded good, but in reality it makes too complex and difficult to manage them. My proposition is to simply make `Event` to an entirely separate entity, and store its name and description individually.

Changes in this PR:
- remove association from event and post in models
- remove those above from the views and `seeds.rb`
- add name and description to event model

**This PR focuses on backend functionality** the look of the pages should be another issue

closes #21 
Probably closes #34 too, because it makes creating an event much more easy and understandable.