### PR TITLE
Cache ruby gems on GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,13 +24,12 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Install rubocop
-        run: bundle install
+      - name: test rubocop
+        run: rubocop -v
 
       - name: Run linters
         uses: wearerequired/lint-action@v1
         with:
           rubocop: true
-          rubocop_dir: /vendor/bundle
           auto_fix: true
           

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,9 +24,6 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: test rubocop
-        run: bundle exec rubocop -v
-
       - name: Run linters
         uses: wearerequired/lint-action@v1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,11 +25,12 @@ jobs:
           bundler-cache: true
 
       - name: test rubocop
-        run: rubocop -v
+        run: bundle exec rubocop -v
 
       - name: Run linters
         uses: wearerequired/lint-action@v1
         with:
           rubocop: true
+          rubocop_command_prefix: bundle exec
           auto_fix: true
           

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,9 +24,13 @@ jobs:
         with:
           bundler-cache: true
 
+      - name: Install rubocop
+        run: bundle install
+
       - name: Run linters
         uses: wearerequired/lint-action@v1
         with:
           rubocop: true
+          rubocop_dir: /vendor/bundle
           auto_fix: true
           

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,12 +22,7 @@ jobs:
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.1
-
-      - name: Set up dependencies
-        run: |
-          gem install bundler
-          bundle install
+          bundler-cache: true
 
       - name: Run linters
         uses: wearerequired/lint-action@v1

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -9,7 +9,9 @@ class AlbumsController < ApplicationController
   end
 
   # GET /albums/1
-  def show; end
+  def show
+
+  end
 
   # GET /albums/new
   def new

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -9,9 +9,7 @@ class AlbumsController < ApplicationController
   end
 
   # GET /albums/1
-  def show
-
-  end
+  def show; end
 
   # GET /albums/new
   def new


### PR DESCRIPTION
- It turns out with the new setup-ruby actions there is no need to manually run bundler, and github takes care of caching gems. 
- Also not setting the ruby version in the action reads it from `.ruby-version` file, which we conveniently have in the repo.