### PR TITLE
Fix docker image node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,10 @@ COPY Gemfile .
 COPY Gemfile.lock .
 RUN bundle install --retry 3
 
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt update && apt install yarn -y
+RUN apt update && apt install nodejs yarn -y
 
 COPY . .
 


### PR DESCRIPTION
Last time when i tried to launch the project on Lois, I got the following error:
`error @rjsf/bootstrap-4@3.0.0: The engine "node" is incompatible with this module. Expected version ">=12". Got "10.24.0"
error Found incompatible module.`

This should do the trick. 