### PR TITLE
Add admin links to navbar

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,6 +2,11 @@ class EventsController < ApplicationController
   before_action :set_event, only: %i[show edit update destroy]
   before_action :check_admin, except: %i[show index]
 
+  # GET /events/list
+  def list
+    @events = Event.all
+  end
+
   # GET /events or /events.json
   def index
     @events = Event.all

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,6 +4,12 @@ class PostsController < ApplicationController
   # Info: https://guides.rubyonrails.org/active_record_querying.html#applying-a-default-scope
   before_action :check_admin, except: %i[show index archive about]
 
+
+  # GET /posts/list
+  def list
+    @posts = Post.all
+  end
+
   # GET /posts
   def index
     @posts = Post.all.order(created_at: :desc).limit(5)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,6 @@ class PostsController < ApplicationController
   # Info: https://guides.rubyonrails.org/active_record_querying.html#applying-a-default-scope
   before_action :check_admin, except: %i[show index archive about]
 
-
   # GET /posts/list
   def list
     @posts = Post.all

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,7 @@ class UsersController < ApplicationController
 
   # GET /users
   def index
-    @users = User.all
+    @users = User.all.order(admin: :desc)
   end
 
   # GET /users/1

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -54,12 +54,14 @@ class UsersController < ApplicationController
   def promote
     @user.admin = true
     @user.save
+    redirect_to users_path
   end
 
   # POST /users/1/promote
   def demote
     @user.admin = false
     @user.save
+    redirect_to users_path
   end
 
   private

--- a/app/views/events/list.html.erb
+++ b/app/views/events/list.html.erb
@@ -36,7 +36,29 @@
           -
         <% end %>
       </td>
+      <td>
+        <div class="btn-group" role="group" aria-label="Műveletek">
+          <%= link_to edit_event_path(event), class: "btn btn-outline-primary btn-sm", title: "Módosítás" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+          <% end %>
+          <%= link_to event,
+                      method: :delete,
+                      data: { confirm: 'Biztosan törlöd?' },
+                      class: "btn btn-outline-danger btn-sm",
+                      title: "Törlés" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+          <% end %>
+        </div>
+      </td>
     </tr>
   <% end %>
   </tbody>
 </table>
+
+<div class="my-3">
+  <%= link_to 'Új esemény', new_event_path, class: "btn btn-primary" %>
+</div>

--- a/app/views/events/list.html.erb
+++ b/app/views/events/list.html.erb
@@ -1,0 +1,42 @@
+<h1 class="my-5">Események</h1>
+
+<table class="table">
+  <thead>
+  <tr>
+    <th>Név</th>
+    <th>Kezdete</th>
+    <th>Vége</th>
+    <th>Jelntkező űrlap</th>
+    <th>Jelntkezők</th>
+    <th></th>
+  </tr>
+  </thead>
+
+  <tbody>
+  <% @events.each do |event| %>
+    <tr>
+      <td><%= link_to event.name, event %></td>
+      <td><%= event.start %></td>
+      <td><%= event.end %>
+      <td>
+        <% if event.event_type %>
+          <%= link_to event.event_type.name, event.event_type %>
+        <% else %>
+          -
+        <% end %>
+      </td>
+      <td>
+        <% if event.event_type %>
+          <% if event.participants.empty? %>
+            Még nincs jelentkező
+          <% else %>
+            <%= link_to "#{event.participants.count} db jelentkező", event_registrations_path(event)  %>
+          <% end %>
+        <% else %>
+          -
+        <% end %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/events/list.html.erb
+++ b/app/views/events/list.html.erb
@@ -6,8 +6,8 @@
     <th>Név</th>
     <th>Kezdete</th>
     <th>Vége</th>
-    <th>Jelntkező űrlap</th>
-    <th>Jelntkezők</th>
+    <th>Jelentkező űrlap</th>
+    <th>Jelentkezők</th>
     <th></th>
   </tr>
   </thead>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,5 +1,5 @@
 <h1 class="my-4">
-  Esemény módosítása
+  Esemény létrehozása
 </h1>
 
 <%= render 'form', event: @event, back_path: events_path %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -23,9 +23,11 @@
         <li class="nav-item">
           <%= link_to 'Rólunk', about_path, class: 'nav-link' %>
         </li>
+      </ul>
+      <ul class="navbar-nav me-right">
         <% if admin_signed_in? %>
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle text-muted" href="#" id="adminDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            <a class="nav-link dropdown-toggle" href="#" id="adminDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" title="Adminisztrátori opciók" aria-label="Adminisztrátori opciók">
               <svg xmlns="http://www.w3.org/2000/svg" height="24" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/>
               </svg>
@@ -46,8 +48,6 @@
             </ul>
           </li>
         <% end %>
-      </ul>
-      <ul class="navbar-nav me-right">
         <% if user_signed_in? %>
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle text-break text-md-end" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -38,7 +38,7 @@
                 <%= link_to "Űrlapok", event_types_path, class: 'dropdown-item' %>
               </li>
               <li>
-                <%= link_to "Bejegyzések", "#", class: 'dropdown-item' %>
+                <%= link_to "Bejegyzések", list_posts_path, class: 'dropdown-item' %>
               </li>
               <li>
                 <%= link_to "Felhasználók", users_path, class: 'dropdown-item' %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -23,6 +23,29 @@
         <li class="nav-item">
           <%= link_to 'Rólunk', about_path, class: 'nav-link' %>
         </li>
+        <% if admin_signed_in? %>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle text-muted" href="#" id="adminDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <svg xmlns="http://www.w3.org/2000/svg" height="24" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/>
+              </svg>
+            </a>
+            <ul aria-labelledby="navbarDropdown" class="dropdown-menu dropdown-menu-end" id="mainNavDropdown">
+              <li>
+                <%= link_to "Események", "#", class: 'dropdown-item' %>
+              </li>
+              <li>
+                <%= link_to "Űrlapok", "#", method: :delete, class: 'dropdown-item' %>
+              </li>
+              <li>
+                <%= link_to "Bejegyzések", "#", method: :delete, class: 'dropdown-item' %>
+              </li>
+              <li>
+                <%= link_to "Felhasználók", "#", method: :delete, class: 'dropdown-item' %>
+              </li>
+            </ul>
+          </li>
+        <% end %>
       </ul>
       <ul class="navbar-nav me-right">
         <% if user_signed_in? %>
@@ -31,26 +54,13 @@
               <%= current_user.name.nil? ? current_user.email : current_user.name %>
             </a>
             <ul aria-labelledby="navbarDropdown" class="dropdown-menu dropdown-menu-end" id="mainNavDropdown">
-              <% if admin_signed_in? %>
-                <li>
-                  <%# TODO: Admin page, see note on project board %>
-                  <%= link_to "Adminisztrátori oldal", "#", class: 'dropdown-item' %>
-                </li>
-                <li>
-                  <%= link_to 'Űrlapok', event_types_path, class: 'dropdown-item' %>
-                </li>
-                <li><hr class="dropdown-divider"></li>
-              <% end %>
               <li>
                 <%# TODO: Profile page, see issue #22 %>
                 <%= link_to "Profil", current_user, class: 'dropdown-item' %>
               </li>
-              <% if !signed_in_via_omniauth? %>
-                <li>
-                  <%= link_to "Felhasználó módosítása", edit_user_path(current_user), class: 'dropdown-item' %>
-                </li>
-              <% end %>
-              <li><hr class="dropdown-divider"></li>
+              <li>
+                <hr class="dropdown-divider">
+              </li>
               <li>
                 <%= link_to "Kijelentkezés", destroy_user_session_path, method: :delete, class: 'dropdown-item' %>
               </li>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -32,16 +32,16 @@
             </a>
             <ul aria-labelledby="navbarDropdown" class="dropdown-menu dropdown-menu-end" id="mainNavDropdown">
               <li>
-                <%= link_to "Események", "#", class: 'dropdown-item' %>
+                <%= link_to "Események", list_events_path, class: 'dropdown-item' %>
               </li>
               <li>
-                <%= link_to "Űrlapok", "#", method: :delete, class: 'dropdown-item' %>
+                <%= link_to "Űrlapok", event_types_path, class: 'dropdown-item' %>
               </li>
               <li>
-                <%= link_to "Bejegyzések", "#", method: :delete, class: 'dropdown-item' %>
+                <%= link_to "Bejegyzések", "#", class: 'dropdown-item' %>
               </li>
               <li>
-                <%= link_to "Felhasználók", "#", method: :delete, class: 'dropdown-item' %>
+                <%= link_to "Felhasználók", users_path, class: 'dropdown-item' %>
               </li>
             </ul>
           </li>

--- a/app/views/posts/list.html.erb
+++ b/app/views/posts/list.html.erb
@@ -44,3 +44,6 @@
   <% end %>
   </tbody>
 </table>
+<div class="my-3">
+  <%= link_to 'Új Poszt', new_post_path, class: "btn btn-primary" %>
+</div>

--- a/app/views/posts/list.html.erb
+++ b/app/views/posts/list.html.erb
@@ -1,0 +1,46 @@
+<h1 class="my-5">Bejegyzések</h1>
+
+<table class="table">
+  <thead>
+  <tr>
+    <th>Cím</th>
+    <th>Létrehozva</th>
+    <th>Indexkép</th>
+    <th></th>
+  </tr>
+  </thead>
+
+  <tbody>
+  <% @posts.each do |post| %>
+    <tr>
+      <td><%= link_to post.title, post %></td>
+      <td><%= post.created_at %></td>
+      <td>
+        <% if post.image.attached? %>
+          van
+        <% else %>
+          nincs
+        <% end %>
+      </td>
+      <td>
+        <div class="btn-group" role="group" aria-label="Műveletek">
+          <%= link_to edit_post_path(post), class: "btn btn-outline-primary btn-sm", title: "Módosítás" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+          <% end %>
+          <%= link_to post,
+                      method: :delete,
+                      data: { confirm: 'Biztosan törlöd?' },
+                      class: "btn btn-outline-danger btn-sm",
+                      title: "Törlés" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+          <% end %>
+        </div>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,73 +2,74 @@
 
 <table class="table">
   <thead>
-    <tr>
-      <th>Név</th>
-      <th>E-mail</th>
-      <th>Admin?</th>
-      <th>AuthSCH?</th>
-      <th></th>
-    </tr>
+  <tr>
+    <th>Név</th>
+    <th>E-mail</th>
+    <th>Admin?</th>
+    <th>AuthSCH?</th>
+    <th></th>
+  </tr>
   </thead>
 
   <tbody>
-    <% @users.each do |user| %>
-      <tr>
-        <td><%= link_to user.name, user %></td>
-        <td><%= user.email %></td>
-        <td>
+  <% @users.each do |user| %>
+    <tr>
+      <td><%= link_to user.name, user %></td>
+      <td><%= user.email %></td>
+      <td>
+        <% if user.admin? %>
+          <svg xmlns="http://www.w3.org/2000/svg" height="24" fill="none" viewBox="0 0 24 24" stroke="green">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+          </svg>
+        <% end %>
+      </td>
+      <td>
+        <% if user.provider == "authsch" %>
+          <svg xmlns="http://www.w3.org/2000/svg" height="24" fill="none" viewBox="0 0 24 24" stroke="green">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+          </svg>
+        <% end %>
+      </td>
+      <td class="text-end">
+        <div class="btn-group" role="group" aria-label="Műveletek">
+          <%= link_to edit_user_path(user), class: "btn btn-outline-primary btn-sm", title: "Módosítás" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+            </svg>
+          <% end %>
           <% if user.admin? %>
-            <svg xmlns="http://www.w3.org/2000/svg" height="24" fill="none" viewBox="0 0 24 24" stroke="green">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+          <%=  link_to demote_user_path(user),
+                        method: :post,
+                        data:   { confirm: 'Biztosan szeretnéd elvenni a felhasználó admin jogát?' },
+                        class:  "btn btn-outline-danger btn-sm",
+                        title:  "Adminjog elvétele" do  %>
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 13l-5 5m0 0l-5-5m5 5V6"/>
             </svg>
-            <%= link_to demote_user_path(user), 
-              method: :post, 
-              data: { confirm: 'Biztosan szeretnéd elvenni a felhasználó admin jogát?' },
-              class: "btn btn-outline-danger btn-sm",
-              title: "Adminjog elvétele" do %>
-              <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 13l-5 5m0 0l-5-5m5 5V6" />
-              </svg>
-            <% end %>
-          <% end %>
-        </td>
-        <td>
-          <% if user.provider == "authsch" %>
-            <svg xmlns="http://www.w3.org/2000/svg" height="24" fill="none" viewBox="0 0 24 24" stroke="green">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+          <%  end  %>
+          <%  else  %>
+          <%=  link_to promote_user_path(user),
+                        method: :post,
+                        data:   { confirm: 'Biztosan szeretnéd adminná tenni a felhasználót?' },
+                        class:  "btn btn-outline-success btn-sm",
+                        title:  "Adminjog adása" do  %>
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11l5-5m0 0l5 5m-5-5v12"/>
+          </svg>
+          <%  end  %>
+          <%  end %>
+          <%= link_to user,
+                      method: :delete,
+                      data:   { confirm: 'Biztosan törlöd?' },
+                      class:  "btn btn-outline-danger btn-sm",
+                      title:  "Törlés" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
             </svg>
           <% end %>
-        </td>
-        <td class="text-end">
-          <div class="btn-group" role="group" aria-label="Műveletek">
-            <%= link_to edit_user_path(user), class: "btn btn-outline-primary btn-sm", title: "Módosítás" do %>
-              <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            <% end %>
-            <% unless user.admin? %>
-              <%= link_to promote_user_path(user), 
-                method: :post, 
-                data: { confirm: 'Biztosan szeretnéd adminná tenni a felhasználót?' }, 
-                class: "btn btn-outline-success btn-sm",
-                title: "Adminjog adása" do %>
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11l5-5m0 0l5 5m-5-5v12" />
-                </svg>
-              <% end %>
-            <% end %>
-            <%= link_to user, 
-              method: :delete, 
-              data: { confirm: 'Biztosan törlöd?' }, 
-              class: "btn btn-outline-danger btn-sm",
-              title: "Törlés" do %>
-              <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            <% end %>
-          </div>
-        </td>
-      </tr>
-    <% end %>
+        </div>
+      </td>
+    </tr>
+  <% end %>
   </tbody>
 </table>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -23,7 +23,7 @@
             </svg>
             <%= link_to demote_user_path(user), 
               method: :post, 
-              data: { confirm: 'Biztosan szeretnéd a felhasználó admin jogát?' }, 
+              data: { confirm: 'Biztosan szeretnéd elvenni a felhasználó admin jogát?' },
               class: "btn btn-outline-danger btn-sm",
               title: "Adminjog elvétele" do %>
               <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
     end
     collection do
       get :archive
+      get :list
     end
   end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,12 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :events
+  resources :events do
+    collection do
+      get :list
+    end
+  end
+
   resources :posts do
     member do
       delete :delete_image


### PR DESCRIPTION
closes #71 
- Instead of a whole admin dashboard i created a drop-down menu for managing the website.
- Created a table for posts and events, because its easier to see through all of the entities this way, than in the landing page or calendar.
- Small typo fixes, and layout rearrangement in user list
