### PR TITLE
User controller

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,7 @@ class UsersController < ApplicationController
   # PATCH/PUT /users/1/force_update (Admin edit)
   def force_update
     if @user.update(user_params)
-      redirect_to @user, notice: "User was successfully updated."
+      redirect_to @user, notice: 'User was successfully updated.'
     else
       render :edit, status: :unprocessable_entity
     end
@@ -57,10 +57,9 @@ class UsersController < ApplicationController
 
   # DELETE /users/1
   def destroy
-
     if user_signed_in? && current_user.admin?
       @user.destroy
-      redirect_to users_url, notice: "User was successfully destroyed."
+      redirect_to users_url, notice: 'User was successfully destroyed.'
     else
       redirect_to cancel_user_registration_path
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: %i[show edit update destroy promote demote]
-  before_action :check_admin, only: %i[index promote demote]
+  before_action :set_user, only: %i[show edit update destroy promote demote force_edit force_update]
+  before_action :check_admin, only: %i[index promote demote force_edit force_update]
   before_action :authenticate_user!, except: %i[new create]
 
   # GET /users
@@ -10,6 +10,18 @@ class UsersController < ApplicationController
 
   # GET /users/1
   def show; end
+
+  # GET /users/1/force_edit (Admin edit)
+  def force_edit; end
+
+  # PATCH/PUT /users/1/force_update (Admin edit)
+  def force_update
+    if @user.update(user_params)
+      redirect_to @user, notice: "User was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
 
   # GET /users/new --- Managed by Devise
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,11 +43,15 @@ class UsersController < ApplicationController
     # end
   end
 
-  # DELETE /users/1 --- Managed by Devise
+  # DELETE /users/1
   def destroy
-    redirect_to cancel_user_registration_path
-    # @user.destroy
-    # redirect_to users_url, notice: "User was successfully destroyed."
+
+    if user_signed_in? && current_user.admin?
+      @user.destroy
+      redirect_to users_url, notice: "User was successfully destroyed."
+    else
+      redirect_to cancel_user_registration_path
+    end
   end
 
   # POST /users/1/promote

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -25,4 +25,9 @@ class Participation < ApplicationRecord
   belongs_to :event
 
   scope :for_event, ->(event_id) { where(event_id: event_id) }
+
+  def can_edit?(user)
+    event.can_participate? && (event.participants.include?(user) || user.admin?)
+  end
+
 end

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -29,5 +29,4 @@ class Participation < ApplicationRecord
   def can_edit?(user)
     event.can_participate? && (event.participants.include?(user) || user.admin?)
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,12 +32,14 @@ class User < ApplicationRecord
   has_many :events, through: :participations
   alias rentals items
   alias participated_events events
+  attribute :admin, default: false
+  validates :name, presence: true, length: { minimum: 3 }
 
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.provider = auth.provider
 
-      data = auth.extra.raw_info
+      data          = auth.extra.raw_info
       user.uid      = data.internal_id
       user.email    = data.mail
       user.name     = data.displayName

--- a/app/views/event_types/index.html.erb
+++ b/app/views/event_types/index.html.erb
@@ -1,7 +1,7 @@
 <h1 class="text-center my-4">Űrlapok</h1>
 
 <div class="row justify-content-center">
-  <div class="col col-md-10 col-lg-8 col-xl-6 col-12">
+  <div class="col col-md-10 col-lg-8 col-xl-6 col-12 table-responsive">
     <table class="table table-sm">
       <thead>
       <tr>
@@ -16,29 +16,29 @@
           <td class="py-2"><%= link_to event_type.name, event_type %></td>
           <td class="text-end">
             <div class="btn-group" role="group" aria-label="Műveletek">
-              <%= link_to edit_event_type_path(event_type), 
-                class: "btn btn-outline-primary btn-sm",
-                title: "Űrlap módosítása" do %>
+              <%= link_to edit_event_type_path(event_type),
+                          class: "btn btn-outline-primary btn-sm",
+                          title: "Űrlap módosítása" do %>
                 <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
                 </svg>
               <% end %>
-              <%= link_to copy_event_type_path(event_type), 
-                method: :post, 
-                data: { confirm: 'Lemásolni készülsz a kiválasztott űrlapot. Folytatás?' },
-                title: "Űrlap másolása",
-                class: "btn btn-outline-primary btn-sm" do %>
+              <%= link_to copy_event_type_path(event_type),
+                          method: :post,
+                          data:   { confirm: 'Lemásolni készülsz a kiválasztott űrlapot. Folytatás?' },
+                          title:  "Űrlap másolása",
+                          class:  "btn btn-outline-primary btn-sm" do %>
                 <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
                 </svg>
               <% end %>
-              <%= link_to event_type, 
-                method: :delete, 
-                data: { confirm: 'Biztosan törlöd?' },
-                title: "Űrlap törlése",
-                class: "btn btn-outline-danger btn-sm" do %>
+              <%= link_to event_type,
+                          method: :delete,
+                          data:   { confirm: 'Biztosan törlöd?' },
+                          title:  "Űrlap törlése",
+                          class:  "btn btn-outline-danger btn-sm" do %>
                 <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
                 </svg>
               <% end %>
             </div>

--- a/app/views/events/list.html.erb
+++ b/app/views/events/list.html.erb
@@ -1,65 +1,68 @@
 <h1 class="my-5">Események</h1>
 
-<table class="table">
-  <thead>
-  <tr>
-    <th>Név</th>
-    <th>Kezdete</th>
-    <th>Vége</th>
-    <th>Jelentkezési határidő</th>
-    <th>Jelentkező űrlap</th>
-    <th>Jelentkezők</th>
-    <th></th>
-  </tr>
-  </thead>
-
-  <tbody>
-  <% @events.each do |event| %>
+<div class="table-responsive">
+  <table class="table">
+    <thead>
     <tr>
-      <td><%= link_to event.name, event %></td>
-      <td><%= event.start %></td>
-      <td><%= event.end %>
-      <td><%= event.event_type ? event.deadline : "-" %></td>
-      <td>
-        <% if event.event_type %>
-          <%= link_to event.event_type.name, event.event_type %>
-        <% else %>
-          -
-        <% end %>
-      </td>
-      <td>
-        <% if event.event_type %>
-          <% if event.participants.empty? %>
-            Még nincs jelentkező
-          <% else %>
-            <%= link_to "#{event.participants.count} db jelentkező", event_registrations_path(event)  %>
-          <% end %>
-        <% else %>
-          -
-        <% end %>
-      </td>
-      <td>
-        <div class="btn-group" role="group" aria-label="Műveletek">
-          <%= link_to edit_event_path(event), class: "btn btn-outline-primary btn-sm", title: "Módosítás" do %>
-            <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-            </svg>
-          <% end %>
-          <%= link_to event,
-                      method: :delete,
-                      data: { confirm: 'Biztosan törlöd?' },
-                      class: "btn btn-outline-danger btn-sm",
-                      title: "Törlés" do %>
-            <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-            </svg>
-          <% end %>
-        </div>
-      </td>
+      <th>Név</th>
+      <th>Kezdete</th>
+      <th>Vége</th>
+      <th>Jelentkezési határidő</th>
+      <th>Jelentkező űrlap</th>
+      <th>Jelentkezők</th>
+      <th></th>
     </tr>
-  <% end %>
-  </tbody>
-</table>
+    </thead>
+
+    <tbody>
+    <% @events.each do |event| %>
+      <tr>
+        <td><%= link_to event.name, event %></td>
+        <td><%= event.start %></td>
+        <td><%= event.end %>
+        <td><%= event.event_type ? event.deadline : "-" %></td>
+        <td>
+          <% if event.event_type %>
+            <%= link_to event.event_type.name, event.event_type %>
+          <% else %>
+            -
+          <% end %>
+        </td>
+        <td>
+          <% if event.event_type %>
+            <% if event.participants.empty? %>
+              Még nincs jelentkező
+            <% else %>
+              <%= link_to "#{event.participants.count} db jelentkező", event_registrations_path(event) %>
+            <% end %>
+          <% else %>
+            -
+          <% end %>
+        </td>
+        <td>
+          <div class="btn-group" role="group" aria-label="Műveletek">
+            <%= link_to edit_event_path(event), class: "btn btn-outline-primary btn-sm", title: "Módosítás" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+              </svg>
+            <% end %>
+            <%= link_to event,
+                        method: :delete,
+                        data:   { confirm: 'Biztosan törlöd?' },
+                        class:  "btn btn-outline-danger btn-sm",
+                        title:  "Törlés" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+              </svg>
+            <% end %>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>
+
 
 <div class="my-3">
   <%= link_to 'Új esemény', new_event_path, class: "btn btn-primary" %>

--- a/app/views/participations/show.html.erb
+++ b/app/views/participations/show.html.erb
@@ -21,5 +21,5 @@
 
 <div class="d-flex justify-content-between my-3">
   <%= link_to 'Vissza', event_path(@participation.event), class: "btn btn-outline-primary" %>
-  <%= link_to 'Módosítás', edit_participation_path(@participation), class: "btn btn-primary" %>
+  <%= link_to 'Módosítás', edit_participation_path(@participation), class: "btn btn-primary" if @participation.can_edit?(current_user) %>
 </div>

--- a/app/views/posts/list.html.erb
+++ b/app/views/posts/list.html.erb
@@ -1,49 +1,52 @@
 <h1 class="my-5">Bejegyzések</h1>
 
-<table class="table">
-  <thead>
-  <tr>
-    <th>Cím</th>
-    <th>Létrehozva</th>
-    <th>Indexkép</th>
-    <th></th>
-  </tr>
-  </thead>
-
-  <tbody>
-  <% @posts.each do |post| %>
+<div class="table-responsive">
+  <table class="table">
+    <thead>
     <tr>
-      <td><%= link_to post.title, post %></td>
-      <td><%= post.created_at %></td>
-      <td>
-        <% if post.image.attached? %>
-          van
-        <% else %>
-          nincs
-        <% end %>
-      </td>
-      <td>
-        <div class="btn-group" role="group" aria-label="Műveletek">
-          <%= link_to edit_post_path(post), class: "btn btn-outline-primary btn-sm", title: "Módosítás" do %>
-            <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-            </svg>
-          <% end %>
-          <%= link_to post,
-                      method: :delete,
-                      data: { confirm: 'Biztosan törlöd?' },
-                      class: "btn btn-outline-danger btn-sm",
-                      title: "Törlés" do %>
-            <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-            </svg>
-          <% end %>
-        </div>
-      </td>
+      <th>Cím</th>
+      <th>Létrehozva</th>
+      <th>Indexkép</th>
+      <th></th>
     </tr>
-  <% end %>
-  </tbody>
-</table>
+    </thead>
+
+    <tbody>
+    <% @posts.each do |post| %>
+      <tr>
+        <td><%= link_to post.title, post %></td>
+        <td><%= post.created_at %></td>
+        <td>
+          <% if post.image.attached? %>
+            van
+          <% else %>
+            nincs
+          <% end %>
+        </td>
+        <td>
+          <div class="btn-group" role="group" aria-label="Műveletek">
+            <%= link_to edit_post_path(post), class: "btn btn-outline-primary btn-sm", title: "Módosítás" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+              </svg>
+            <% end %>
+            <%= link_to post,
+                        method: :delete,
+                        data:   { confirm: 'Biztosan törlöd?' },
+                        class:  "btn btn-outline-danger btn-sm",
+                        title:  "Törlés" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+              </svg>
+            <% end %>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>
+
 <div class="my-3">
   <%= link_to 'Új Poszt', new_post_path, class: "btn btn-primary" %>
 </div>

--- a/app/views/rents/closed.html.erb
+++ b/app/views/rents/closed.html.erb
@@ -8,43 +8,46 @@
     <% end %>
   </div>
 </div>
-<table class="table">
-  <thead>
-  <tr>
-    <th>Bérlő</th>
-    <th>Felvéve</th>
-    <th>Időtartam</th>
-    <th>Felszerelések</th>
-    <th></th>
-  </tr>
-  </thead>
-
-  <tbody>
-  <% @rents.each do |rent| %>
+<div class="table-responsive">
+  <table class="table">
+    <thead>
     <tr>
-      <td><%= rent.user.name %></td>
-      <td><%= rent.created_at %></td>
-      <td><%= l rent.start_date %> - <%= l rent.end_date %></td>
-      <td><%= rent.compact_order %></td>
-      <td>
-        <div class="btn-group" role="group" aria-label="Műveletek">
-          <%= link_to edit_rent_path(rent), class: "btn btn-outline-primary btn-sm", title: "Módosítás" do %>
-            <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
-            </svg>
-          <% end %>
-          <%= link_to rent,
-                      method: :delete,
-                      data:   { confirm: 'Biztosan törlöd?' },
-                      class:  "btn btn-outline-danger btn-sm",
-                      title:  "Törlés" do %>
-            <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
-            </svg>
-          <% end %>
-        </div>
-      </td>
+      <th>Bérlő</th>
+      <th>Felvéve</th>
+      <th>Időtartam</th>
+      <th>Felszerelések</th>
+      <th></th>
     </tr>
-  <% end %>
-  </tbody>
-</table>
+    </thead>
+
+    <tbody>
+    <% @rents.each do |rent| %>
+      <tr>
+        <td><%= rent.user.name %></td>
+        <td><%= rent.created_at %></td>
+        <td><%= l rent.start_date %> - <%= l rent.end_date %></td>
+        <td><%= rent.compact_order %></td>
+        <td>
+          <div class="btn-group" role="group" aria-label="Műveletek">
+            <%= link_to edit_rent_path(rent), class: "btn btn-outline-primary btn-sm", title: "Módosítás" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+              </svg>
+            <% end %>
+            <%= link_to rent,
+                        method: :delete,
+                        data:   { confirm: 'Biztosan törlöd?' },
+                        class:  "btn btn-outline-danger btn-sm",
+                        title:  "Törlés" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+              </svg>
+            <% end %>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>
+

--- a/app/views/users/force_edit.html.erb
+++ b/app/views/users/force_edit.html.erb
@@ -1,0 +1,32 @@
+<h1 class="text-center my-4">Felhasználói adatok módosítása</h1>
+
+<%= form_with(model: @user, local: true, url: force_update_user_path) do |form| %>
+  <%= render 'layouts/errors', errors: @user.errors %>
+
+  <div class="mb-2">
+    <%= form.label :name, class: "form-label" %>
+    <%= form.text_field :name, class: "form-control" %>
+  </div>
+
+  <div class="mb-2">
+    <%= form.label :email, class: "form-label" %>
+    <%= form.text_field :email, class: "form-control" %>
+  </div>
+
+  <div class="mb-2">
+    <%= form.label :admin, class: "form-check-label" do %>
+      <%= form.check_box :admin %>
+      Admin jog
+    <% end %>
+  </div>
+
+  <div class="alert alert-warning" role="alert">
+    Jelenleg Admin jogosultsággal szerkeszted a felhasználót, kérlek légy óvatos mit állítasz át!
+  </div>
+
+  <div class="my-3 d-flex justify-content-between">
+    <%= link_to "Vissza", users_path, class: "btn btn-outline-primary" %>
+    <%= form.submit class: "btn btn-primary" %>
+  </div>
+
+<% end %>

--- a/app/views/users/force_edit.html.erb
+++ b/app/views/users/force_edit.html.erb
@@ -26,7 +26,7 @@
 
   <div class="my-3 d-flex justify-content-between">
     <%= link_to "Vissza", users_path, class: "btn btn-outline-primary" %>
-    <%= form.submit class: "btn btn-primary" %>
+    <%= form.submit class: "btn btn-primary text-wrap" %>
   </div>
 
 <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,75 +1,78 @@
 <h1 class="my-5">Felhasználók</h1>
 
-<table class="table">
-  <thead>
-  <tr>
-    <th>Név</th>
-    <th>E-mail</th>
-    <th>Admin?</th>
-    <th>AuthSCH?</th>
-    <th></th>
-  </tr>
-  </thead>
-
-  <tbody>
-  <% @users.each do |user| %>
+<div class="table-responsive">
+  <table class="table">
+    <thead>
     <tr>
-      <td><%= link_to user.name, user %></td>
-      <td><%= user.email %></td>
-      <td>
-        <% if user.admin? %>
-          <svg xmlns="http://www.w3.org/2000/svg" height="24" fill="none" viewBox="0 0 24 24" stroke="green">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
-          </svg>
-        <% end %>
-      </td>
-      <td>
-        <% if user.provider == "authsch" %>
-          <svg xmlns="http://www.w3.org/2000/svg" height="24" fill="none" viewBox="0 0 24 24" stroke="green">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
-          </svg>
-        <% end %>
-      </td>
-      <td class="text-end">
-        <div class="btn-group" role="group" aria-label="Műveletek">
-          <%= link_to force_edit_user_path(user), class: "btn btn-outline-primary btn-sm", title: "Módosítás" do %>
-            <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
-            </svg>
-          <% end %>
-          <% if user.admin? %>
-          <%=  link_to demote_user_path(user),
-                        method: :post,
-                        data:   { confirm: 'Biztosan szeretnéd elvenni a felhasználó admin jogát?' },
-                        class:  "btn btn-outline-danger btn-sm",
-                        title:  "Adminjog elvétele" do  %>
-            <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 13l-5 5m0 0l-5-5m5 5V6"/>
-            </svg>
-          <%  end  %>
-          <%  else  %>
-          <%=  link_to promote_user_path(user),
-                        method: :post,
-                        data:   { confirm: 'Biztosan szeretnéd adminná tenni a felhasználót?' },
-                        class:  "btn btn-outline-success btn-sm",
-                        title:  "Adminjog adása" do  %>
-          <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11l5-5m0 0l5 5m-5-5v12"/>
-          </svg>
-          <%  end  %>
-          <%  end %>
-          <%= link_to user,
-                      method: :delete,
-                      data:   { confirm: 'Biztosan törlöd?' },
-                      class:  "btn btn-outline-danger btn-sm",
-                      title:  "Törlés" do %>
-            <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
-            </svg>
-          <% end %>
-        </div>
-      </td>
+      <th>Név</th>
+      <th>E-mail</th>
+      <th>Admin?</th>
+      <th>AuthSCH?</th>
+      <th></th>
     </tr>
-  <% end %>
-  </tbody>
-</table>
+    </thead>
+
+    <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td><%= link_to user.name, user %></td>
+        <td><%= user.email %></td>
+        <td>
+          <% if user.admin? %>
+            <svg xmlns="http://www.w3.org/2000/svg" height="24" fill="none" viewBox="0 0 24 24" stroke="green">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+            </svg>
+          <% end %>
+        </td>
+        <td>
+          <% if user.provider == "authsch" %>
+            <svg xmlns="http://www.w3.org/2000/svg" height="24" fill="none" viewBox="0 0 24 24" stroke="green">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+            </svg>
+          <% end %>
+        </td>
+        <td class="text-end">
+          <div class="btn-group" role="group" aria-label="Műveletek">
+            <%= link_to force_edit_user_path(user), class: "btn btn-outline-primary btn-sm", title: "Módosítás" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+              </svg>
+            <% end %>
+            <% if user.admin? %>
+              <%=  link_to demote_user_path(user),
+                           method: :post,
+                           data:   { confirm: 'Biztosan szeretnéd elvenni a felhasználó admin jogát?' },
+                           class:  "btn btn-outline-danger btn-sm",
+                           title:  "Adminjog elvétele" do  %>
+                <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 13l-5 5m0 0l-5-5m5 5V6"/>
+                </svg>
+              <%  end  %>
+            <%  else  %>
+              <%=  link_to promote_user_path(user),
+                           method: :post,
+                           data:   { confirm: 'Biztosan szeretnéd adminná tenni a felhasználót?' },
+                           class:  "btn btn-outline-success btn-sm",
+                           title:  "Adminjog adása" do  %>
+                <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11l5-5m0 0l5 5m-5-5v12"/>
+                </svg>
+              <%  end  %>
+            <%  end %>
+            <%= link_to user,
+                        method: :delete,
+                        data:   { confirm: 'Biztosan törlöd?' },
+                        class:  "btn btn-outline-danger btn-sm",
+                        title:  "Törlés" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+              </svg>
+            <% end %>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>
+

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -32,7 +32,7 @@
       </td>
       <td class="text-end">
         <div class="btn-group" role="group" aria-label="Műveletek">
-          <%= link_to edit_user_path(user), class: "btn btn-outline-primary btn-sm", title: "Módosítás" do %>
+          <%= link_to force_edit_user_path(user), class: "btn btn-outline-primary btn-sm", title: "Módosítás" do %>
             <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
             </svg>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,17 +12,17 @@
       <div class="card-body text-center row justify-content-lg-center justify-content-start">
         <div class="col-auto text-start">
           <p>
-            <strong>Név: </strong><%= @user.name %>
+            <strong>Név:&nbsp;</strong><%= @user.name %>
           </p>
           <p>
-            <strong>Email: </strong><%= @user.email %>
+            <strong>Email:&nbsp;</strong><%= @user.email %>
           </p>
           <% if admin_signed_in? %>
             <p>
-              <strong>Provider: </strong><%= @user.provider %>
+              <strong>Provider:&nbsp;</strong><%= @user.provider %>
             </p>
             <p>
-              <strong>Admin: </strong><%= @user.admin %>
+              <strong>Admin:&nbsp;</strong><%= @user.admin %>
             </p>
           <% end %>
           <% if admin_signed_in? %>
@@ -41,13 +41,13 @@
       <div class="card-header text-center">
         <h5>Regisztrált események</h5>
       </div>
-      <div class="card-body">
+      <div class="card-body  table-responsive">
         <table class="table">
           <thead>
           <tr>
             <th>Esemény</th>
             <th>Időpont</th>
-            <th>Regsiztráció</th>
+            <th>Regisztráció</th>
           </tr>
           </thead>
           <tbody>
@@ -94,7 +94,7 @@
       <div class="card-header text-center">
         <h5>Eszközbérlések</h5>
       </div>
-      <div class="card-body">
+      <div class="card-body table-responsive">
         <table class="table">
           <thead>
           <tr>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,7 +25,11 @@
               <strong>Admin: </strong><%= @user.admin %>
             </p>
           <% end %>
-          <%= link_to 'Módosítás', edit_user_path(@user), class: "btn btn-primary" %>
+          <% if admin_signed_in? %>
+            <%= link_to 'Módosítás', force_edit_user_path(@user), class: "btn btn-primary" %>
+          <% else %>
+            <%= link_to 'Módosítás', edit_user_path(@user), class: "btn btn-primary" %>
+          <% end %>
         </div>
       </div>
     </div>
@@ -47,33 +51,33 @@
           </tr>
           </thead>
           <tbody>
-          <% if @user.participations.empty?%>
+          <% if @user.participations.empty? %>
             <tr>
               <td colspan="3"> Még nem regisztráltál egy eseményre sem!</td>
             </tr>
           <% end %>
           <% @user.participations.each do |p| %>
-          <tr>
-            <td><%= link_to p.event.name, p.event %></td>
-            <td><%= l p.event.start %></td>
-            <td>
-              <div class="btn-group" role="group" aria-label="Műveletek">
-                <%= link_to p, class: "btn btn-outline-primary btn-sm", title: "Megtekintés" do %>
-                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-eye-fill" viewBox="0 0 16 16">
-                    <path d="M10.5 8a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0z"/>
-                    <path d="M0 8s3-5.5 8-5.5S16 8 16 8s-3 5.5-8 5.5S0 8 0 8zm8 3.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z"/>
-                  </svg>
-                <% end %>
-                <% if p.can_edit?(current_user) %>
-                  <%= link_to edit_participation_path(p), class: "btn btn-outline-primary btn-sm", title: "Módosítás" do %>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+            <tr>
+              <td><%= link_to p.event.name, p.event %></td>
+              <td><%= l p.event.start %></td>
+              <td>
+                <div class="btn-group" role="group" aria-label="Műveletek">
+                  <%= link_to p, class: "btn btn-outline-primary btn-sm", title: "Megtekintés" do %>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-eye-fill" viewBox="0 0 16 16">
+                      <path d="M10.5 8a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0z"/>
+                      <path d="M0 8s3-5.5 8-5.5S16 8 16 8s-3 5.5-8 5.5S0 8 0 8zm8 3.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z"/>
                     </svg>
                   <% end %>
-                <% end %>
-              </div>
-            </td>
-          </tr>
+                  <% if p.can_edit?(current_user) %>
+                    <%= link_to edit_participation_path(p), class: "btn btn-outline-primary btn-sm", title: "Módosítás" do %>
+                      <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+                      </svg>
+                    <% end %>
+                  <% end %>
+                </div>
+              </td>
+            </tr>
           <% end %>
           </tbody>
         </table>
@@ -101,7 +105,7 @@
           </tr>
           </thead>
           <tbody>
-          <% if @user.rents.empty?%>
+          <% if @user.rents.empty? %>
             <tr>
               <td colspan="4"> Még nem béreltél egy eszközt sem!</td>
             </tr>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,24 +1,132 @@
-<p class="fs-5 mt-4 mb-2">
-  <strong>Név:</strong>
-  <%= @user.name %>
-</p>
+<div class="row">
+  <div class="col-12">
+    <div class="card">
+      <div class="card-header text-center">
+        <span class="text-muted">
+          <svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" fill="currentColor" class="bi bi-person-circle" viewBox="0 0 16 16">
+          <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0z"/>
+          <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1z"/>
+        </svg>
+        </span>
+      </div>
+      <div class="card-body text-center row justify-content-lg-center justify-content-start">
+        <div class="col-auto text-start">
+          <p>
+            <strong>Név: </strong><%= @user.name %>
+          </p>
+          <p>
+            <strong>Email: </strong><%= @user.email %>
+          </p>
+          <% if admin_signed_in? %>
+            <p>
+              <strong>Provider: </strong><%= @user.provider %>
+            </p>
+            <p>
+              <strong>Admin: </strong><%= @user.admin %>
+            </p>
+          <% end %>
+          <%= link_to 'Módosítás', edit_user_path(@user), class: "btn btn-primary" %>
+        </div>
+      </div>
+    </div>
+  </div>
 
-<p class="fs-5 my-2">
-  <strong>E-mail:</strong>
-  <%= @user.email %>
-</p>
 
-<p class="fs-5 my-2">
-  <strong>Admin:</strong>
-  <%= @user.admin %>
-</p>
+  <div class="col-12 mt-5">
+    <div class="card">
+      <div class="card-header text-center">
+        <h5>Regisztrált események</h5>
+      </div>
+      <div class="card-body">
+        <table class="table">
+          <thead>
+          <tr>
+            <th>Esemény</th>
+            <th>Időpont</th>
+            <th>Regsiztráció</th>
+          </tr>
+          </thead>
+          <tbody>
+          <% if @user.participations.empty?%>
+            <tr>
+              <td colspan="3"> Még nem regisztráltál egy eseményre sem!</td>
+            </tr>
+          <% end %>
+          <% @user.participations.each do |p| %>
+          <tr>
+            <td><%= link_to p.event.name, p.event %></td>
+            <td><%= l p.event.start %></td>
+            <td>
+              <div class="btn-group" role="group" aria-label="Műveletek">
+                <%= link_to p, class: "btn btn-outline-primary btn-sm", title: "Megtekintés" do %>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-eye-fill" viewBox="0 0 16 16">
+                    <path d="M10.5 8a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0z"/>
+                    <path d="M0 8s3-5.5 8-5.5S16 8 16 8s-3 5.5-8 5.5S0 8 0 8zm8 3.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z"/>
+                  </svg>
+                <% end %>
+                <% if p.can_edit?(current_user) %>
+                  <%= link_to edit_participation_path(p), class: "btn btn-outline-primary btn-sm", title: "Módosítás" do %>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+                    </svg>
+                  <% end %>
+                <% end %>
+              </div>
+            </td>
+          </tr>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
 
-<p class="fs-5 my-2">
-  <strong>Provider:</strong>
-  <%= @user.provider %>
-</p>
+  <%
+    classes = { pending: "text-secondary", accepted: "text-primary", rented: "text-info", closed: "text-danger" }
+  %>
 
-<div class="d-flex justify-content-between my-5">
-  <%= link_to 'Vissza', users_path, class: "btn btn-outline-primary" %>
-  <%= link_to 'Módosítás', edit_user_path(@user), class: "btn btn-primary" %>
+  <div class="col-12 mt-5">
+    <div class="card">
+      <div class="card-header text-center">
+        <h5>Eszközbérlések</h5>
+      </div>
+      <div class="card-body">
+        <table class="table">
+          <thead>
+          <tr>
+            <th>Felszerelés</th>
+            <th>Időtartam</th>
+            <th>Státusz</th>
+            <th></th>
+          </tr>
+          </thead>
+          <tbody>
+          <% if @user.rents.empty?%>
+            <tr>
+              <td colspan="4"> Még nem béreltél egy eszközt sem!</td>
+            </tr>
+          <% end %>
+          <% @user.rents.order(status: :asc).each do |rent| %>
+            <tr>
+              <td><%= rent.compact_order %></td>
+              <td><%= l rent.start_date %> - <%= l rent.end_date %></td>
+              <td class="<%= classes[rent.status.to_sym] %>"><%= t rent.status %></td>
+              <td>
+                <div class="btn-group" role="group" aria-label="Műveletek">
+                  <%= link_to rent, class: "btn btn-outline-primary btn-sm", title: "Megtekintés" do %>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-eye-fill" viewBox="0 0 16 16">
+                      <path d="M10.5 8a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0z"/>
+                      <path d="M0 8s3-5.5 8-5.5S16 8 16 8s-3 5.5-8 5.5S0 8 0 8zm8 3.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z"/>
+                    </svg>
+                  <% end %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,9 @@ Rails.application.routes.draw do
     member do
       post :demote
       post :promote
+      get :force_edit
+      put :force_update
+      patch :force_update
     end
   end
 


### PR DESCRIPTION
Refactor the user system to be a bit more usable.
- Allow admins to delete/edit other users to some degree (i.e name for users provided by `authsch`)
- Add a user page, where users can see their info (rn only `name&email` that is relevant), and can see their own rents and registered events
- Fix some minor issues:
    * User list ordered wrong, because `admin` field defaults to `nil` instead of `false`
    * Users can register without providing a name

closes #129 and closes #22